### PR TITLE
Extend if condition for detached HEAD

### DIFF
--- a/BuildVersion.ps1
+++ b/BuildVersion.ps1
@@ -253,7 +253,7 @@ StringTruncate ([Ref]$Url) 255
 # https://stackoverflow.com/a/12142066 
 try {
     $Branch = git -C $ProjectPath branch --show-current 2> $Null
-    if($LASTEXITCODE -ne 0) {
+    if($LASTEXITCODE -ne 0 -or $null -eq $Branch) {
         LogWarning "Local repository is in a headless state"
         $Branch = "Unknown"
     }


### PR DESCRIPTION
When building a project with MS Devops the buildagent checks out a commit and not a branch. This results in a detached HEAD.
In this case the exit code $LASTEXITCODE of 'git branch --show-current' is unreliable. In a branch and detached $LASTEXITCODE is 0.

I extended the if condition here to check for $LASTEXITCODE and for '$null -eq $Branch.