### PR TITLE
Account for staged changes in UncommittedChanges

### DIFF
--- a/BuildVersion.ps1
+++ b/BuildVersion.ps1
@@ -317,7 +317,7 @@ StringTruncate ([Ref]$Sha1)
 
 # Uncommitted changes
 try {
-    $UncommittedChanges = git -C $ProjectPath diff --shortstat 2> $Null
+    $UncommittedChanges = git -C $ProjectPath diff --shortstat --merge-base HEAD 2> $Null
     if($LASTEXITCODE -ne 0) {
         $UncommittedChanges = "Unknown"
         $ChangeWarning = 0


### PR DESCRIPTION
Hi,

thanks for the useful project, worked very well out of the box 👍 .

Just noticed that the `UncommittedChanges` did not include staged/cached changes. I think this is unintended hence this PR.

Adding `--merge-base HEAD` should fix this (did it for me at least 😉). Quoting [git doc](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-gitdiffoptions--merge-basecommit--path):
> This form is to view the changes you have in your working tree relative to the named commit. You can use HEAD to compare it with the latest commit, or a branch name to compare with the tip of a different branch.

-- Lukas